### PR TITLE
Added pagination when displaying posts on the first page.

### DIFF
--- a/src/main/resources/WebApp/src/app/app.module.ts
+++ b/src/main/resources/WebApp/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { EditAuthorComponent } from './component/edit-author/edit-author.compone
 import { ValidationErrorsComponent } from './component/validation-errors/validation-errors.component';
 import {TranslateLoader, TranslateModule} from '@ngx-translate/core';
 import {TranslateHttpLoader} from '@ngx-translate/http-loader';
+import { PaginatorComponent } from './component/paginator/paginator.component';
 
 export function createTranslateLoader(http: HttpClient) {
   return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -36,7 +37,8 @@ export function createTranslateLoader(http: HttpClient) {
     PostComponent,
     EditPostComponent,
     EditAuthorComponent,
-    ValidationErrorsComponent
+    ValidationErrorsComponent,
+    PaginatorComponent
   ],
   imports: [
     BrowserModule,

--- a/src/main/resources/WebApp/src/app/component/main/main.component.html
+++ b/src/main/resources/WebApp/src/app/component/main/main.component.html
@@ -2,13 +2,19 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-8 col-md-10 mx-auto">
-      <div *ngFor="let post of posts">
+      <div *ngFor="let post of posts[currentPage]">
         <app-post-preview [post]="post" ></app-post-preview>
       </div>
       <!-- Pager -->
+      <app-paginator
+        [numberOfPages] = "posts.length"
+        (pageNumberClick)="updatePage($event)">
+      </app-paginator>
+      <!--
       <div class="clearfix">
         <a class="btn btn-primary float-right" href="#">Older Posts &rarr;</a>
       </div>
+      -->
     </div>
   </div>
 </div>

--- a/src/main/resources/WebApp/src/app/component/main/main.component.ts
+++ b/src/main/resources/WebApp/src/app/component/main/main.component.ts
@@ -8,16 +8,111 @@ import {PostService} from '../../service/post/post.service';
   styleUrls: ['./main.component.scss']
 })
 export class MainComponent implements OnInit {
+  currentPage: number;
 
-  posts: PostDto[];
+  /*posts: PostDto[];*/
+  posts: PostDto[][]; /*first dimention for the page,and second dimention for the Post*/
+
   constructor(private postService: PostService) { }
 
   ngOnInit() {
+    /*
     this.postService.getAllPosts().subscribe(
       posts => {
         this.posts = posts;
       }
     );
+    */
+    this.currentPage = 0;
+
+    this.posts = [
+      // Page 1
+      [
+        {
+          id: 1,
+          title: 'Post 1',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        },
+        {
+          id: 2,
+          title: 'Post 2',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        },
+        {
+          id: 3,
+          title: 'Post 3',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        },
+        {
+          id: 4,
+          title: 'Post 4',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        }
+      ],
+      // Page 2
+      [
+        {
+          id: 5,
+          title: 'Post 5',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        },
+        {
+          id: 6,
+          title: 'Post 6',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        },
+        {
+          id: 7,
+          title: 'Post 7',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        },
+        {
+          id: 8,
+          title: 'Post 8',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        }
+      ],
+      // Page 3
+      [
+        {
+          id: 9,
+          title: 'Post 9',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        },
+        {
+          id: 10,
+          title: 'Post 10',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        },
+        {
+          id: 11,
+          title: 'Post 11',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        },
+        {
+          id: 12,
+          title: 'Post 12',
+          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec lobortis turpis at ipsum hendrerit, vel porttitor velit ultrices.',
+          date: '01.08.2020'
+        }
+      ]
+    ];
+
+  }
+
+  updatePage(newPage){
+    this.currentPage = newPage;
   }
 
 }

--- a/src/main/resources/WebApp/src/app/component/paginator/paginator.component.html
+++ b/src/main/resources/WebApp/src/app/component/paginator/paginator.component.html
@@ -1,0 +1,6 @@
+<ul class="pagination">
+  <li *ngFor="let page of pages; index as i" class="page-item">
+    <a class="page-link" href="#"
+    (click) = "pageNumberClicked(i)">{{i + 1}}</a>
+  </li>
+</ul>

--- a/src/main/resources/WebApp/src/app/component/paginator/paginator.component.spec.ts
+++ b/src/main/resources/WebApp/src/app/component/paginator/paginator.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PaginatorComponent } from './paginator.component';
+
+describe('PaginatorComponent', () => {
+  let component: PaginatorComponent;
+  let fixture: ComponentFixture<PaginatorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PaginatorComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PaginatorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/main/resources/WebApp/src/app/component/paginator/paginator.component.ts
+++ b/src/main/resources/WebApp/src/app/component/paginator/paginator.component.ts
@@ -1,0 +1,23 @@
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+
+@Component({
+  selector: 'app-paginator',
+  templateUrl: './paginator.component.html',
+  styleUrls: ['./paginator.component.scss']
+})
+export class PaginatorComponent implements OnInit {
+
+  @Input() numberOfPages;
+  @Output() pageNumberClick = new EventEmitter<number>();
+  pages: number[];
+
+  constructor() { }
+
+  ngOnInit() {
+    this.pages = new Array(this.numberOfPages);
+  }
+  pageNumberClicked(pageNumber){
+    this.pageNumberClick.emit(pageNumber);
+  }
+
+}


### PR DESCRIPTION
#9 
In this solution hardcoded data is used for 'posts', because this solution requires 2 dimensional array as 'posts' instead of 1 dimensional array, first dimension for page and the second for posts. The backend currently sends only list of posts.
Despite using Pagination Component from Bootstrap, the bootstrap classes aren't applied.
